### PR TITLE
Fix unexpected argument error when passing logx or logy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.pyc
 __pycache__/
 *.egg-info/
+examples/output/

--- a/examples/log-line-plot.py
+++ b/examples/log-line-plot.py
@@ -1,0 +1,31 @@
+"""A simple line plot example"""
+
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+sys.path.append(".")
+sys.path.append("..")
+from pssgplot import PlotEnvironment
+from pssgplot.lineplot import LinePlot
+
+with PlotEnvironment(font_path=Path("../fonts/gillsans.ttf")):
+    df = pd.DataFrame(
+        {
+            "x": [0, 100, 2200, 3050, 40800],
+            "y": [0, 200, 1000, 3000, 40000],
+        }
+    )
+
+    simple_line = LinePlot()
+    simple_line.plot(
+        data=df, x="x", y="y", logx=10, logy=10, title="A log-log line plot", markers=True
+    )
+
+    # Use .animate to save an animation of the plot
+    simple_line.animate(by="column", save_dir=Path("output"))
+
+    # Use .show or .save to output the figure
+    # simple_line.show()
+    simple_line.save("output/log-line-plot.pdf", format="pdf")

--- a/examples/log-line-plot.py
+++ b/examples/log-line-plot.py
@@ -1,4 +1,4 @@
-"""A simple line plot example"""
+"""A simple log-log line plot example"""
 
 import sys
 from pathlib import Path

--- a/examples/log-line-plot.py
+++ b/examples/log-line-plot.py
@@ -13,8 +13,8 @@ from pssgplot.lineplot import LinePlot
 with PlotEnvironment(font_path=Path("../fonts/gillsans.ttf")):
     df = pd.DataFrame(
         {
-            "x": [0, 100, 2200, 3050, 40800],
-            "y": [0, 200, 1000, 3000, 40000],
+            "x": [1, 100, 2200, 3050, 40800],
+            "y": [1, 200, 1000, 3000, 40000],
         }
     )
 

--- a/pssgplot/barplot.py
+++ b/pssgplot/barplot.py
@@ -69,10 +69,10 @@ class BarPlot(Plot):
             self.ax.set_ylabel(ylabel, fontsize=ylabel_fontsize)
 
         if logx is not None:
-            self.ax.set_xscale('log', basex=logx)
+            self.ax.set_xscale('log', base=logx)
         
         if logy is not None:
-            self.ax.set_yscale('log', basey=logy)
+            self.ax.set_yscale('log', base=logy)
         
         if xlim is not None:
             self.ax.set_xlim(xlim)

--- a/pssgplot/lineplot.py
+++ b/pssgplot/lineplot.py
@@ -68,10 +68,10 @@ class LinePlot(Plot):
             self.ax.set_ylabel(ylabel, fontsize=ylabel_fontsize)
 
         if logx is not None:
-            self.ax.set_xscale('log', basex=logx)
+            self.ax.set_xscale('log', base=logx)
 
         if logy is not None:
-            self.ax.set_yscale('log', basey=logy)
+            self.ax.set_yscale('log', base=logy)
 
         if xlim is not None:
             self.ax.set_xlim(xlim)


### PR DESCRIPTION
- Tried adjusting the line plot example to use log-log scale and encountered this error:
```
Traceback (most recent call last):
  File "/home/jkitson/work/epicast/pssg-plots/examples/simple-line-plot.py", line 15, in <module>
    simple_line.plot(data=df, x="nodes",
  File "/home/jkitson/work/epicast/pssg-plots/examples/../pssgplot/lineplot.py", line 71, in plot
    self.ax.set_xscale('log', basex=logx)
  File "/home/jkitson/.local/lib/python3.10/site-packages/matplotlib/axes/_base.py", line 73, in wrapper
    return get_method(self)(*args, **kwargs)
  File "/home/jkitson/.local/lib/python3.10/site-packages/matplotlib/axis.py", line 837, in _set_axes_scale
    ax._axis_map[name]._set_scale(value, **kwargs)
  File "/home/jkitson/.local/lib/python3.10/site-packages/matplotlib/axis.py", line 796, in _set_scale
    self._scale = mscale.scale_factory(value, self, **kwargs)
  File "/home/jkitson/.local/lib/python3.10/site-packages/matplotlib/scale.py", line 717, in scale_factory
    return scale_cls(axis, **kwargs)
TypeError: LogScale.__init__() got an unexpected keyword argument 'basex'
```
- Fixed this error by switching from using base{x,y} -> base when calling set_{x,y} scale to fix unexpected argument error

Suspect that this might come down to a versioning issue, but putting this PR here in case someone else ran into the same bug