### PR TITLE
Add pyproject.toml and bundle fonts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .venv
 *.pyc
 __pycache__/
+*.egg-info/

--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ A lightweight Python plotting library for creating plots in the PSSG style.
 
 ## Simple Bar Chart Demo
 
-Aquick demo of plotting a simple bar chart:
+A quick demo of plotting a simple bar chart:
 
 ```python
 from pssgplot import PlotEnvironment, BarPlot
 import pandas as pd
 
-with PlotEnvironment(font_path='fonts/gillsans.ttf'):
+with PlotEnvironment():
     df = pd.DataFrame({
         "x": ["A", "B", "C", "D"],
         "y": [1, 2, 3, 4],
@@ -26,6 +26,21 @@ with PlotEnvironment(font_path='fonts/gillsans.ttf'):
     
     chart.save('output/simple-bar-chart.png')
 ```
+
+## Installing and Setup
+
+Setting up with _uv_ is straightforward:
+
+```bash
+uv venv
+source .venv/bin/activate
+
+uv pip install -e pssg-plots/
+
+uv run plotting-script.py
+```
+
+You can also just use vanilla pip and virtualenvs if you'd like.
 
 ## Examples
 

--- a/pssgplot/pssgplot.py
+++ b/pssgplot/pssgplot.py
@@ -2,7 +2,9 @@
 """
 # std imports
 from os import PathLike
+from pathlib import Path
 from typing import List, Optional, Union
+import warnings
 
 # tpl imports
 from matplotlib.font_manager import FontProperties, fontManager
@@ -50,12 +52,8 @@ class PlotEnvironment:
         """
         if interactive and backend is not None:
             raise ValueError("interactive and backend cannot both be specified.")
-
-        if font_name is not None and font_path is not None:
-            raise ValueError("Only one of font_name and font_path may be specified.")
         
-        if font_path is not None:
-            font_name = self._load_font(font_path)
+        font_name = self._resolve_font(font_name, font_path)
 
         if font_scale <= 0:
             raise ValueError("font_scale must be positive.")
@@ -104,3 +102,39 @@ class PlotEnvironment:
         """ load a font into matplotlib and return its name """
         fontManager.addfont(font_path)
         return FontProperties(fname=font_path).get_name()
+
+    def _resolve_font(self, font_name: Optional[str], font_path: Optional[str]) -> str:
+        """ Resolves the font to use for plotting.
+            If neither font_name nor font_path is specified, look for the Gill Sans MT or Gill Sans font packaged with this library.
+                If it is not found, look for a systems Gill Sans or Gill Sans MT font. If it is still not found, print a warning and use the default font.
+            If font_name is specified, use it.
+            If font_path is specified, load the font from the path and use it.
+            If both are specified, raise an error.
+        """
+        if font_name is not None and font_path is not None:
+            raise ValueError("Only one of font_name and font_path may be specified.")
+
+        if font_path is not None:
+            return self._load_font(font_path)
+        
+        if font_name is not None:
+            return font_name
+        
+        # Use bundled Gill Sans font if available
+        bundled_font_path = Path(__file__).parent.parent / "fonts" / "gillsans.ttf"
+        if bundled_font_path.exists():
+            return self._load_font(bundled_font_path)
+        
+        # Look for system Gill Sans or Gill Sans MT fonts
+        available_fonts = [f.name for f in fontManager.ttflist]
+        for font_candidate in ['Gill Sans MT', 'Gill Sans', 'GillSans']:
+            if font_candidate in available_fonts:
+                return font_candidate
+        
+        # Fall back to default font with warning
+        warnings.warn(
+            "Gill Sans font not found. Using default sans-serif font. "
+            "For best results, install Gill Sans or specify a custom font.",
+            UserWarning
+        )
+        return "sans-serif"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,60 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "pssgplot"
+version = "0.1.0"
+description = "A lightweight Python plotting library for creating plots in the PSSG style"
+readme = "README.md"
+requires-python = ">=3.8"
+license = {text = "MIT"}
+authors = [
+    {name = "PSSG Team"}
+]
+keywords = ["plotting", "visualization", "charts", "matplotlib"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Scientific/Engineering :: Visualization",
+]
+
+dependencies = [
+    "pandas>=2.0.0",
+    "matplotlib>=3.7.0",
+    "seaborn>=0.13.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0",
+    "black>=23.0",
+    "flake8>=6.0",
+]
+
+[project.urls]
+Homepage = "https://github.com/hpcgroup/pssg-plots"
+Repository = "https://github.com/hpcgroup/pssg-plots"
+
+[tool.setuptools]
+packages = ["pssgplot"]
+
+[tool.setuptools.package-data]
+pssgplot = ["*.ttf", "fonts/*.ttf"]
+
+[tool.black]
+line-length = 88
+target-version = ["py38", "py39", "py310", "py311"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = ["test_*.py"]
+python_classes = ["Test*"]
+python_functions = ["test_*"]


### PR DESCRIPTION
Adds a pyproject.toml to make installing the plotting library in a virtualenv and using it easier.

Also distributes the font directly in the package, so no quirky path is needed.
If not found for some reason, then it falls back to system font or user supplied font.