### PR TITLE
Adds heatmaps in the style of those from the portability and PCCL papers

### DIFF
--- a/examples/simple-heatmap.py
+++ b/examples/simple-heatmap.py
@@ -18,10 +18,10 @@ with PlotEnvironment(font_path='../fonts/gillsans.ttf'):
                   0.5,0.3,0.1,0.2,
                   1.2,1.05,1.6,2.1]
     })
-    bounds = [0.25, 0.5, 0.9, 1.1, 1.5, 2.0]
     hm = Heatmap()
     hm.plot(
         data=df,
+        row="x",
         row="x",
         col="y",
         value="value",

--- a/examples/simple-heatmap.py
+++ b/examples/simple-heatmap.py
@@ -1,0 +1,40 @@
+""" A simple heatmap example """
+import sys
+sys.path.append('.')
+sys.path.append('..')
+from pssgplot import PlotEnvironment, Heatmap
+import pandas as pd
+import numpy as np
+
+with PlotEnvironment(font_path='../fonts/gillsans.ttf'):
+    df = pd.DataFrame({
+        "x": [0,1,2,3,
+              0,1,2,3,
+              0,1,2,3],
+        "y": [0,0,0,0,
+              1,1,1,1,
+              2,2,2,2],
+        "value": [0.8,0.5,0.3,0.1,
+                  0.5,0.3,0.1,0.2,
+                  1.2,1.05,1.6,2.1]
+    })
+    hm = Heatmap()
+    hm.plot(
+        data=df,
+        row="x",
+        col="y",
+        value="value",
+        title="Simple Heatmap",
+        bounds=[0.25, 0.5, 0.9, 1.1, 1.5, 2.0],
+        colors=["#BD0026", "#FD8D3C", "#C7E9B4", "#41B6C4", "#253494"],
+        annot_fmt=lambda v: f"{v:.1f}" if v >= 1 else f"{v:.2f}",
+        cbar_label="Speedup",
+        cbar_ticks=[0.5, 0.75, 1, 2, 4, 8],
+    )
+
+    # use .animate to save a row-by-row animation of the heatmap
+    hm.animate(by='row', save_dir='output')
+
+    # use .show or .save to output the figure
+    # hm.show()
+    hm.save('output/simple-heatmap.pdf', format='pdf')

--- a/examples/simple-heatmap.py
+++ b/examples/simple-heatmap.py
@@ -4,9 +4,9 @@ sys.path.append('.')
 sys.path.append('..')
 from pssgplot import PlotEnvironment, Heatmap
 import pandas as pd
-import numpy as np
+from pathlib import Path
 
-with PlotEnvironment(font_path='../fonts/gillsans.ttf'):
+with PlotEnvironment(font_path=Path('../fonts/gillsans.ttf')):
     df = pd.DataFrame({
         "x": [0,1,2,3,
               0,1,2,3,
@@ -33,7 +33,7 @@ with PlotEnvironment(font_path='../fonts/gillsans.ttf'):
     )
 
     # use .animate to save a row-by-row animation of the heatmap
-    hm.animate(by='row', save_dir='output')
+    hm.animate(by='row', save_dir=Path('output'))
 
     # use .show or .save to output the figure
     # hm.show()

--- a/examples/simple-heatmap.py
+++ b/examples/simple-heatmap.py
@@ -21,9 +21,8 @@ with PlotEnvironment(font_path='../fonts/gillsans.ttf'):
     hm = Heatmap()
     hm.plot(
         data=df,
-        row="x",
-        row="x",
-        col="y",
+        row="y",
+        col="x",
         value="value",
         title="Simple Heatmap",
         bounds=[0.25, 0.5, 0.9, 1.1, 1.5, 1.75],

--- a/examples/simple-heatmap.py
+++ b/examples/simple-heatmap.py
@@ -18,6 +18,7 @@ with PlotEnvironment(font_path='../fonts/gillsans.ttf'):
                   0.5,0.3,0.1,0.2,
                   1.2,1.05,1.6,2.1]
     })
+    bounds = [0.25, 0.5, 0.9, 1.1, 1.5, 2.0]
     hm = Heatmap()
     hm.plot(
         data=df,
@@ -25,11 +26,11 @@ with PlotEnvironment(font_path='../fonts/gillsans.ttf'):
         col="y",
         value="value",
         title="Simple Heatmap",
-        bounds=[0.25, 0.5, 0.9, 1.1, 1.5, 2.0],
-        colors=["#BD0026", "#FD8D3C", "#C7E9B4", "#41B6C4", "#253494"],
+        bounds=[0.25, 0.5, 0.9, 1.1, 1.5, 1.75],
+        colors=["#d73027","#fc8d59","#fee090","#ffffbf","#e0f3f8","#91bfdb","#4575b4"],
         annot_fmt=lambda v: f"{v:.1f}" if v >= 1 else f"{v:.2f}",
         cbar_label="Speedup",
-        cbar_ticks=[0.5, 0.75, 1, 2, 4, 8],
+        cbar_extend="both"
     )
 
     # use .animate to save a row-by-row animation of the heatmap

--- a/pssgplot/__init__.py
+++ b/pssgplot/__init__.py
@@ -3,4 +3,5 @@ from .pssgplot import PlotEnvironment
 from .plot import Plot
 from .lineplot import LinePlot
 from .barplot import BarPlot
+from .heatmap import Heatmap
 from .boxplot import BoxPlot

--- a/pssgplot/heatmap.py
+++ b/pssgplot/heatmap.py
@@ -45,6 +45,8 @@ class Heatmap(Plot):
         bounds: Optional[List[float]],
         colors: Optional[List[str]],
         cmap: Union[str, Colormap, None],
+        vmin: Optional[float],
+        vmax: Option[float],
         extend: Union[str, None],
     ) -> Tuple[Union[str, Colormap], Optional[mcolors.Normalize]]:
         if bounds is not None:

--- a/pssgplot/heatmap.py
+++ b/pssgplot/heatmap.py
@@ -54,7 +54,6 @@ class Heatmap(Plot):
                 )
             n_bins = len(bounds) - 1
 
-            base = plt.get_cmap(cmap) if isinstance(cmap, str) else cmap
             listed = mcolors.ListedColormap(colors)
             norm = mcolors.BoundaryNorm(
                 bounds,

--- a/pssgplot/heatmap.py
+++ b/pssgplot/heatmap.py
@@ -204,8 +204,10 @@ class Heatmap(Plot):
             os.makedirs(save_dir)
 
         original = self.data.values.astype(float)
-        n_frames = original.shape[0] if by == 'row' else original.shape[1]
+        n_rows, n_cols = original.shape
+        n_frames = n_rows if by == 'row' else n_cols
         mesh = self.ax.collections[0]
+        texts = self.ax.texts
 
         for frame in range(n_frames):
             masked = np.full_like(original, np.nan)
@@ -214,6 +216,13 @@ class Heatmap(Plot):
             else:
                 masked[:, :frame + 1] = original[:, :frame + 1]
             mesh.set_array(masked.ravel())
+
+            if len(texts) == n_rows * n_cols:
+                for i in range(n_rows):
+                    for j in range(n_cols):
+                        visible = (i <= frame) if by == 'row' else (j <= frame)
+                        texts[i * n_cols + j].set_visible(visible)
+
             self.fig.savefig(
                 os.path.join(save_dir, f"frame_{frame}.{frame_format}"),
                 **kwargs,

--- a/pssgplot/heatmap.py
+++ b/pssgplot/heatmap.py
@@ -46,7 +46,7 @@ class Heatmap(Plot):
         colors: Optional[List[str]],
         cmap: Union[str, Colormap, None],
         vmin: Optional[float],
-        vmax: Option[float],
+        vmax: Optional[float],
         extend: Union[str, None],
     ) -> Tuple[Union[str, Colormap], Optional[mcolors.Normalize]]:
         if bounds is not None:

--- a/pssgplot/heatmap.py
+++ b/pssgplot/heatmap.py
@@ -47,7 +47,7 @@ class Heatmap(Plot):
         cmap: Union[str, Colormap, None],
         vmin: Optional[float],
         vmax: Optional[float],
-        extend: Union[str, None],
+        extend: Union[str, None] = "neither",
     ) -> Tuple[Union[str, Colormap], Optional[Normalize]]:
         if bounds is not None:
             if colors is None:
@@ -113,7 +113,7 @@ class Heatmap(Plot):
         cbar_label: Optional[str] = None,
         cbar_ticks: Optional[List[float]] = None,
         cbar_ticklabels: Optional[List[str]] = None,
-        cbar_extend: Optional[str] = None,
+        cbar_extend: Optional[str] = "neither",
         linewidths: float = 0.5,
         linecolor: str = "white",
         **kwargs,

--- a/pssgplot/heatmap.py
+++ b/pssgplot/heatmap.py
@@ -7,7 +7,7 @@ import os
 import matplotlib.pyplot as plt
 import matplotlib.colors as mcolors
 from matplotlib.axes import Axes
-from matplotlib.colors import Colormap
+from matplotlib.colors import Colormap, Normalize
 import numpy as np
 import pandas as pd
 import seaborn as sns
@@ -46,15 +46,14 @@ class Heatmap(Plot):
         colors: Optional[List[str]],
         cmap: Union[str, Colormap, None],
         vmin: Optional[float],
-        vmax: Option[float],
+        vmax: Optional[float],
         extend: Union[str, None],
-    ) -> Tuple[Union[str, Colormap], Optional[mcolors.Normalize]]:
+    ) -> Tuple[Union[str, Colormap], Optional[Normalize]]:
         if bounds is not None:
             if colors is None:
                 raise ValueError(
                     "When 'bounds' is provided, 'colors' must also be provided and not None."
                 )
-            n_bins = len(bounds) - 1
 
             listed = mcolors.ListedColormap(colors)
             norm = mcolors.BoundaryNorm(
@@ -64,7 +63,11 @@ class Heatmap(Plot):
                 extend=extend,
             )
             return listed, norm
-        return cmap, None
+        elif vmin is not None or vmax is not None:
+            norm = Normalize(vmin=vmin, vmax=vmax)
+            return cmap, norm
+        else:
+            return cmap, None
 
     @staticmethod
     def _build_annot_matrix(

--- a/pssgplot/heatmap.py
+++ b/pssgplot/heatmap.py
@@ -50,8 +50,6 @@ class Heatmap(Plot):
         extend: Optional[str,None],
     ) -> Tuple[Union[str, Colormap], Optional[mcolors.Normalize]]:
         if bounds is not None:
-            n_bins = len(bounds) - 1
-            
             base = plt.get_cmap(cmap) if isinstance(cmap, str) else cmap
             listed = mcolors.ListedColormap(colors)
             norm = mcolors.BoundaryNorm(bounds, ncolors=len(colors), clip=extend is None, extend=extend)

--- a/pssgplot/heatmap.py
+++ b/pssgplot/heatmap.py
@@ -45,14 +45,23 @@ class Heatmap(Plot):
         bounds: Optional[List[float]],
         colors: Optional[List[str]],
         cmap: Union[str, Colormap, None],
-        vmin: Optional[float],
-        vmax: Optional[float],
-        extend: Optional[str,None],
+        extend: Optional[str, None],
     ) -> Tuple[Union[str, Colormap], Optional[mcolors.Normalize]]:
         if bounds is not None:
+            if colors is None:
+                raise ValueError(
+                    "When 'bounds' is provided, 'colors' must also be provided and not None."
+                )
+            n_bins = len(bounds) - 1
+
             base = plt.get_cmap(cmap) if isinstance(cmap, str) else cmap
             listed = mcolors.ListedColormap(colors)
-            norm = mcolors.BoundaryNorm(bounds, ncolors=len(colors), clip=extend is None, extend=extend)
+            norm = mcolors.BoundaryNorm(
+                bounds,
+                ncolors=len(colors),
+                clip=extend is None,
+                extend=extend,
+            )
             return listed, norm
         return cmap, None
 

--- a/pssgplot/heatmap.py
+++ b/pssgplot/heatmap.py
@@ -1,13 +1,13 @@
 """ Wrapper class to plot a heatmap. """
 # std imports
-from typing import Callable, List, Optional, Tuple, Union
+from typing import Callable, List, Optional, Tuple, Union, Literal
 import os
 
 # tpl imports
 import matplotlib.pyplot as plt
 import matplotlib.colors as mcolors
 from matplotlib.axes import Axes
-from matplotlib.colors import Colormap, Normalize
+from matplotlib.colors import Colormap, Normalize, BoundaryNorm
 import numpy as np
 import pandas as pd
 import seaborn as sns
@@ -44,11 +44,12 @@ class Heatmap(Plot):
     def _build_norm(
         bounds: Optional[List[float]],
         colors: Optional[List[str]],
-        cmap: Union[str, Colormap, None],
+        cmap: Union[str, Colormap],
         vmin: Optional[float],
         vmax: Optional[float],
-        extend: Union[str, None] = "neither",
-    ) -> Tuple[Union[str, Colormap], Optional[Normalize]]:
+        extend: Literal["neither", "both", "min", "max"] = "neither",
+    ) -> Tuple[Union[str, Colormap], Union[BoundaryNorm, Normalize, None]]:
+        norm: Union[BoundaryNorm, Normalize, None] = None
         if bounds is not None:
             if colors is None:
                 raise ValueError(
@@ -81,12 +82,14 @@ class Heatmap(Plot):
                 if pd.isna(v):
                     result[i, j] = ""
                 elif callable(annot_fmt):
+                    if not isinstance(v, (int, float)):
+                        raise ValueError(f"Value {v!r} is not a number.")
                     result[i, j] = annot_fmt(v)
                 else:
                     result[i, j] = annot_fmt.format(v)
         return result
 
-    def plot(
+    def plot(  # type: ignore[override]
         self,
         data: pd.DataFrame,
         row: Optional[str] = None,
@@ -101,7 +104,7 @@ class Heatmap(Plot):
         figsize: Tuple[float, float] = (6, 4.5),
         ax: Optional[Axes] = None,
         tight_layout: bool = True,
-        cmap: Union[str, Colormap, None] = "YlOrRd",
+        cmap: Union[str, Colormap] = "YlOrRd",
         vmin: Optional[float] = None,
         vmax: Optional[float] = None,
         bounds: Optional[List[float]] = None,
@@ -113,7 +116,7 @@ class Heatmap(Plot):
         cbar_label: Optional[str] = None,
         cbar_ticks: Optional[List[float]] = None,
         cbar_ticklabels: Optional[List[str]] = None,
-        cbar_extend: Optional[str] = "neither",
+        cbar_extend: Literal["neither", "both", "min", "max"] = "neither",
         linewidths: float = 0.5,
         linecolor: str = "white",
         **kwargs,
@@ -128,6 +131,7 @@ class Heatmap(Plot):
 
         resolved_cmap, norm = self._build_norm(bounds, colors, cmap, vmin, vmax, cbar_extend)
 
+        annot_data: Union[np.ndarray, bool]
         if annot and annot_fmt is not None:
             annot_data = self._build_annot_matrix(self.data, annot_fmt)
             fmt = ""
@@ -135,9 +139,10 @@ class Heatmap(Plot):
             annot_data = annot
             fmt = ".2g"
 
-        cbar_kws = {}
+        cbar_kws: dict[str, List[float] | Literal["neither", "both", "min", "max"]] = {}
         if cbar_ticks is not None:
             cbar_kws["ticks"] = cbar_ticks
+        cbar_kws["extend"] = cbar_extend
 
         heatmap_kwargs = dict(
             cmap=resolved_cmap,
@@ -158,8 +163,12 @@ class Heatmap(Plot):
 
         if cbar and (cbar_label is not None or cbar_ticklabels is not None):
             colorbar = self.ax.collections[0].colorbar
+            if colorbar is None:
+                raise ValueError("Colorbar not found.")
             if cbar_label is not None:
-                colorbar.set_label(cbar_label)
+                if cbar_ticks is None:
+                    cbar_ticks = list(colorbar.get_ticks())
+                colorbar.set_ticks(cbar_ticks, labels=cbar_ticklabels)
             if cbar_ticklabels is not None:
                 colorbar.set_ticklabels(cbar_ticklabels)
 
@@ -173,12 +182,12 @@ class Heatmap(Plot):
         self.ax.spines['left'].set_color('#606060')
         self.ax.spines['bottom'].set_color('#606060')
 
-        if tight_layout:
+        if tight_layout and isinstance(self.fig, plt.Figure):
             self.fig.tight_layout()
 
         return self.ax
 
-    def animate(
+    def animate(  # type: ignore[override]
         self,
         by: str,
         save_dir: os.PathLike,

--- a/pssgplot/heatmap.py
+++ b/pssgplot/heatmap.py
@@ -45,7 +45,7 @@ class Heatmap(Plot):
         bounds: Optional[List[float]],
         colors: Optional[List[str]],
         cmap: Union[str, Colormap, None],
-        extend: Optional[str, None],
+        extend: Union[str, None],
     ) -> Tuple[Union[str, Colormap], Optional[mcolors.Normalize]]:
         if bounds is not None:
             if colors is None:

--- a/pssgplot/heatmap.py
+++ b/pssgplot/heatmap.py
@@ -47,21 +47,14 @@ class Heatmap(Plot):
         cmap: Union[str, Colormap, None],
         vmin: Optional[float],
         vmax: Optional[float],
+        extend: Optional[str,None],
     ) -> Tuple[Union[str, Colormap], Optional[mcolors.Normalize]]:
         if bounds is not None:
             n_bins = len(bounds) - 1
-            if colors is not None:
-                if len(colors) != n_bins:
-                    raise ValueError(
-                        f"len(colors) ({len(colors)}) must equal len(bounds) - 1 ({n_bins})."
-                    )
-                listed = mcolors.ListedColormap(colors)
-            else:
-                base = plt.get_cmap(cmap) if isinstance(cmap, str) else cmap
-                listed = mcolors.ListedColormap(
-                    [base(i / n_bins) for i in range(n_bins)]
-                )
-            norm = mcolors.BoundaryNorm(bounds, ncolors=n_bins, clip=True)
+            
+            base = plt.get_cmap(cmap) if isinstance(cmap, str) else cmap
+            listed = mcolors.ListedColormap(colors)
+            norm = mcolors.BoundaryNorm(bounds, ncolors=len(colors), clip=extend is None, extend=extend)
             return listed, norm
         return cmap, None
 
@@ -109,6 +102,7 @@ class Heatmap(Plot):
         cbar_label: Optional[str] = None,
         cbar_ticks: Optional[List[float]] = None,
         cbar_ticklabels: Optional[List[str]] = None,
+        cbar_extend: Optional[str] = None,
         linewidths: float = 0.5,
         linecolor: str = "white",
         **kwargs,
@@ -121,7 +115,7 @@ class Heatmap(Plot):
             self.ax = ax
             self.fig = ax.get_figure()
 
-        resolved_cmap, norm = self._build_norm(bounds, colors, cmap, vmin, vmax)
+        resolved_cmap, norm = self._build_norm(bounds, colors, cmap, vmin, vmax, cbar_extend)
 
         if annot and annot_fmt is not None:
             annot_data = self._build_annot_matrix(self.data, annot_fmt)

--- a/pssgplot/heatmap.py
+++ b/pssgplot/heatmap.py
@@ -1,0 +1,215 @@
+""" Wrapper class to plot a heatmap. """
+# std imports
+from typing import Callable, List, Optional, Tuple, Union
+import os
+
+# tpl imports
+import matplotlib.pyplot as plt
+import matplotlib.colors as mcolors
+from matplotlib.axes import Axes
+from matplotlib.colors import Colormap
+import numpy as np
+import pandas as pd
+import seaborn as sns
+
+# local imports
+from pssgplot import Plot
+
+
+class Heatmap(Plot):
+
+    def __init__(self):
+        self.fig = None
+        self.ax = None
+        self.data = None
+
+    @staticmethod
+    def _pivot_data(
+        data: pd.DataFrame,
+        row: Optional[str],
+        col: Optional[str],
+        value: Optional[str],
+    ) -> pd.DataFrame:
+        specified = [x for x in (row, col, value) if x is not None]
+        if len(specified) == 0:
+            return data
+        if len(specified) == 3:
+            return data.pivot(index=row, columns=col, values=value)
+        raise ValueError(
+            "row, col, and value must all be provided together, or all omitted "
+            "(to pass a pre-pivoted DataFrame)."
+        )
+
+    @staticmethod
+    def _build_norm(
+        bounds: Optional[List[float]],
+        colors: Optional[List[str]],
+        cmap: Union[str, Colormap, None],
+        vmin: Optional[float],
+        vmax: Optional[float],
+    ) -> Tuple[Union[str, Colormap], Optional[mcolors.Normalize]]:
+        if bounds is not None:
+            n_bins = len(bounds) - 1
+            if colors is not None:
+                if len(colors) != n_bins:
+                    raise ValueError(
+                        f"len(colors) ({len(colors)}) must equal len(bounds) - 1 ({n_bins})."
+                    )
+                listed = mcolors.ListedColormap(colors)
+            else:
+                base = plt.get_cmap(cmap) if isinstance(cmap, str) else cmap
+                listed = mcolors.ListedColormap(
+                    [base(i / n_bins) for i in range(n_bins)]
+                )
+            norm = mcolors.BoundaryNorm(bounds, ncolors=n_bins, clip=True)
+            return listed, norm
+        return cmap, None
+
+    @staticmethod
+    def _build_annot_matrix(
+        pivot: pd.DataFrame,
+        annot_fmt: Union[str, Callable[[float], str]],
+    ) -> np.ndarray:
+        result = np.empty(pivot.shape, dtype=object)
+        for i in range(pivot.shape[0]):
+            for j in range(pivot.shape[1]):
+                v = pivot.iloc[i, j]
+                if pd.isna(v):
+                    result[i, j] = ""
+                elif callable(annot_fmt):
+                    result[i, j] = annot_fmt(v)
+                else:
+                    result[i, j] = annot_fmt.format(v)
+        return result
+
+    def plot(
+        self,
+        data: pd.DataFrame,
+        row: Optional[str] = None,
+        col: Optional[str] = None,
+        value: Optional[str] = None,
+        title: Optional[str] = None,
+        title_fontsize: Optional[int] = None,
+        xlabel: Optional[str] = None,
+        xlabel_fontsize: Optional[int] = None,
+        ylabel: Optional[str] = None,
+        ylabel_fontsize: Optional[int] = None,
+        figsize: Tuple[float, float] = (6, 4.5),
+        ax: Optional[Axes] = None,
+        tight_layout: bool = True,
+        cmap: Union[str, Colormap, None] = "YlOrRd",
+        vmin: Optional[float] = None,
+        vmax: Optional[float] = None,
+        bounds: Optional[List[float]] = None,
+        colors: Optional[List[str]] = None,
+        annot: bool = True,
+        annot_fmt: Union[str, Callable[[float], str], None] = None,
+        annot_fontsize: Optional[int] = None,
+        cbar: bool = True,
+        cbar_label: Optional[str] = None,
+        cbar_ticks: Optional[List[float]] = None,
+        cbar_ticklabels: Optional[List[str]] = None,
+        linewidths: float = 0.5,
+        linecolor: str = "white",
+        **kwargs,
+    ) -> Axes:
+        self.data = self._pivot_data(data, row, col, value)
+
+        if ax is None:
+            self.fig, self.ax = plt.subplots(figsize=figsize)
+        else:
+            self.ax = ax
+            self.fig = ax.get_figure()
+
+        resolved_cmap, norm = self._build_norm(bounds, colors, cmap, vmin, vmax)
+
+        if annot and annot_fmt is not None:
+            annot_data = self._build_annot_matrix(self.data, annot_fmt)
+            fmt = ""
+        else:
+            annot_data = annot
+            fmt = ".2g"
+
+        cbar_kws = {}
+        if cbar_ticks is not None:
+            cbar_kws["ticks"] = cbar_ticks
+
+        heatmap_kwargs = dict(
+            cmap=resolved_cmap,
+            norm=norm,
+            annot=annot_data,
+            fmt=fmt,
+            annot_kws={"fontsize": annot_fontsize} if annot_fontsize is not None else {},
+            linewidths=linewidths,
+            linecolor=linecolor,
+            cbar=cbar,
+            cbar_kws=cbar_kws,
+        )
+        if norm is None:
+            heatmap_kwargs["vmin"] = vmin
+            heatmap_kwargs["vmax"] = vmax
+
+        sns.heatmap(self.data, ax=self.ax, **heatmap_kwargs, **kwargs)
+
+        if cbar and (cbar_label is not None or cbar_ticklabels is not None):
+            colorbar = self.ax.collections[0].colorbar
+            if cbar_label is not None:
+                colorbar.set_label(cbar_label)
+            if cbar_ticklabels is not None:
+                colorbar.set_ticklabels(cbar_ticklabels)
+
+        if title is not None:
+            self.ax.set_title(title, fontsize=title_fontsize)
+        if xlabel is not None:
+            self.ax.set_xlabel(xlabel, fontsize=xlabel_fontsize)
+        if ylabel is not None:
+            self.ax.set_ylabel(ylabel, fontsize=ylabel_fontsize)
+
+        self.ax.spines['left'].set_color('#606060')
+        self.ax.spines['bottom'].set_color('#606060')
+
+        if tight_layout:
+            self.fig.tight_layout()
+
+        return self.ax
+
+    def animate(
+        self,
+        by: str,
+        save_dir: os.PathLike,
+        frame_format: str = 'pdf',
+        **kwargs,
+    ):
+        """
+        Animate the heatmap by progressively revealing rows or columns.
+
+        Produces one frame per step and saves each to save_dir.
+
+        Args:
+            by (str): Either 'row' or 'col'.
+            save_dir (PathLike): Directory to save frames into.
+            frame_format (str): File format for frames (e.g. 'pdf', 'png').
+        """
+        if self.ax is None or self.fig is None:
+            raise ValueError("plot() must be called before animate().")
+        if by not in ('row', 'col'):
+            raise ValueError("'by' must be 'row' or 'col'.")
+
+        if not os.path.exists(save_dir):
+            os.makedirs(save_dir)
+
+        original = self.data.values.astype(float)
+        n_frames = original.shape[0] if by == 'row' else original.shape[1]
+        mesh = self.ax.collections[0]
+
+        for frame in range(n_frames):
+            masked = np.full_like(original, np.nan)
+            if by == 'row':
+                masked[:frame + 1, :] = original[:frame + 1, :]
+            else:
+                masked[:, :frame + 1] = original[:, :frame + 1]
+            mesh.set_array(masked.ravel())
+            self.fig.savefig(
+                os.path.join(save_dir, f"frame_{frame}.{frame_format}"),
+                **kwargs,
+            )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "pssgplot"
 version = "0.1.0"
 description = "A lightweight Python plotting library for creating plots in the PSSG style"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.8.1"
 license = {text = "MIT"}
 authors = [
     {name = "PSSG Team"}
@@ -30,6 +30,7 @@ dependencies = [
     "pandas>=2.0.0",
     "matplotlib>=3.7.0",
     "seaborn>=0.13.0",
+    "pandas-stubs>=2.0.3.230814",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
- Added `Heatmap` wrapper class for `sns.heatmap`
- Implemented support for discrete heatmaps with and without bound extensions (i.e. arrows at end of bounds)
- Added simple example heatmap